### PR TITLE
Ref kmers

### DIFF
--- a/src/nib.nim
+++ b/src/nib.nim
@@ -1,5 +1,9 @@
-from nibpkg/compose import compose_variants
+from nibpkg/compose import nil
+from nibpkg/refmers import nil
 
-if isMainModule:
+when isMainModule:
   import cligen
-  dispatch(compose_variants)
+  dispatchMulti(
+        [compose.compose_variants, cmdName="compose"],
+        [refmers.countRefKmers, cmdName="count"],
+  )

--- a/src/nibpkg/refmers.nim
+++ b/src/nibpkg/refmers.nim
@@ -1,0 +1,18 @@
+import hts
+
+
+proc coutRefKmers(input_fn: string) =
+    ##Walk over reference sequences and count kmers
+    var fai: Fai
+    if not fai.open(input_fn):
+        quit "couldn't open fasta"
+
+
+    for i in 0..<fai.len:
+        let chrom_name = fai[i]
+        let chrom_len = fai.chrom_len(chrom_name)
+        var full_sequence = fai.get(chrom_name)
+
+when isMainModule:
+    import cligen
+    dispatch(coutRefKmers)

--- a/src/nibpkg/refmers.nim
+++ b/src/nibpkg/refmers.nim
@@ -1,18 +1,12 @@
 import hts
 
-
-proc coutRefKmers(input_fn: string) =
+proc countRefKmers*(input_fn: string) =
     ##Walk over reference sequences and count kmers
     var fai: Fai
     if not fai.open(input_fn):
         quit "couldn't open fasta"
 
-
     for i in 0..<fai.len:
         let chrom_name = fai[i]
         let chrom_len = fai.chrom_len(chrom_name)
         var full_sequence = fai.get(chrom_name)
-
-when isMainModule:
-    import cligen
-    dispatch(coutRefKmers)

--- a/tests/t_welcome.nim
+++ b/tests/t_welcome.nim
@@ -1,5 +1,5 @@
 # vim: sw=4 ts=4 sts=4 tw=0 et:
-from nibsvpkg/welcome import nil
+from nibpkg/welcome import nil
 import unittest
 
 suite "welcome":


### PR DESCRIPTION
```
% make

% src/nib -h
Usage:
  nib {SUBCMD}  [sub-command options & parameters]
where {SUBCMD} is one of:
  help              print comprehensive or per-cmd help
  compose  function to compose Open FASTA index
  count      Walk over reference sequences and count kmers

% src/nib compose -h
Usage:
  count [required&optional-params]
Walk over reference sequences and count kmers
Options:
  -h, --help                          print this cligen-erated help
  --help-syntax                       advanced: prepend,plurals,..
  -i=, --input-fn=  string  REQUIRED  set input_fn
```