### PR TITLE
Add a counting array class

### DIFF
--- a/src/nibpkg/counting_array.nim
+++ b/src/nibpkg/counting_array.nim
@@ -1,0 +1,15 @@
+type
+    CountingArray*[T] = ref object
+        values: seq(int32)
+        size: int32
+
+proc create[T](counter: type CountingArray, size: int32) =
+    counter.values = newSeq(T)[size]
+    counter.size = size
+
+proc add[T](counter: type CountingArray, val: T) =
+    counter.values [int64(val) mod int64(counter.size)] =
+        counter.values [int64(val) mod int64(counter.size)] + 1
+
+proc get[T](counter: type CountingArray, val: T): int32 =
+    return counter.values[int64(val) mod int64(counter.size)]


### PR DESCRIPTION
I _think_ this adds a generic counting array class, which can replace a hashmap when collisions can be allowed.

I'm not sure how to allocate an array dynamically in Nim, so I've used a seq. Each value has a max counter value of INT32_MAX. I also saw some discussion of class-like syntax sugar for Nim types, but I'm not sure the below usage is actually valid.

Basic usage:
```
## Create array for int32 values
var counter = new CountingArray[int32]

## Create a backing array with 1024 indices. More indices = more memory, but fewer collisions.
counter.create(1024)

## Increment the counter for the value 42
counter.add(42)

## Get the counter for the value 42. returns 1.
counter.get(42)
```