### PR TITLE
[classify] Add classify function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /nimbleDir
 /nib
 /src/nib
+tests/test_read
+tests/test_svidx

--- a/src/nib.nim
+++ b/src/nib.nim
@@ -8,4 +8,5 @@ when isMainModule:
         [compose.compose_variants, cmdName="compose"],
         [refmers.showCounts, cmdName="count"],
         [mainLookup.buildSVIdx, cmdName="lookup"],
+        [classify.main_classify, cmdName="classify"],
   )

--- a/src/nib.nim
+++ b/src/nib.nim
@@ -1,6 +1,7 @@
 from nibpkg/compose import nil
 from nibpkg/refmers import nil
 from nibpkg/mainLookup import nil
+from nibpkg/classify import nil
 
 when isMainModule:
   import cligen

--- a/src/nibpkg/classify.nim
+++ b/src/nibpkg/classify.nim
@@ -5,28 +5,30 @@ import ./mainLookup
 import ./read
 import ./svidx
 
-proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32, uint32] =
-    result = newCountTable[uint32, uint32]()
+proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32] =
+    result = newCountTable[uint32]()
 
     var bamfile:Bam
     open(bamfile, filename, index=false)
+    var sequence: string
 
     for record in bamfile:
-        var read_classification = process_read(record.sequence, idx, k)
+        record.sequence(sequence)
+
+        var read_classification = process_read(sequence, idx, k)
         filter_read_matches(read_classification)
         for key, val in read_classification.compatible_SVs:
-            result.mgetOrPut(key, val)
+            result.inc(key, val)
 
 
-proc classify_file(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32, uint32] =
-    
+proc classify_file(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32] =
+
     if endsWith(filename, ".bam"):
         return classify_bam(filename, idx, k)
     else:
         quit("Error: only BAM input currently supported.")
 
-proc main_classify(read_file : string, vcf_file : string, ref_file : string, k:int=25, flank:int=100) =
+proc main_classify*(read_file : string, vcf_file : string, ref_file : string, k:int=25, flank:int=100) =
 
     var idx : svIdx = buildSVIdx(ref_file, vcf_file, flank, k)
-
-    var svCounts: CountTableRef[uint32, uint32] = classify_file(read_file, idx, k)
+    var svCounts: CountTableRef[uint32] = classify_file(read_file, idx, k)

--- a/src/nibpkg/classify.nim
+++ b/src/nibpkg/classify.nim
@@ -23,3 +23,6 @@ proc classify_file(filename : string, idx : svIdx): CountTableRef =
         return classify_bam
     else:
         quit("Error: only BAM input currently supported.")
+
+proc main_classify(read_file : string, vcf_file : string, ref_file : string, k:int=25) =
+    

--- a/src/nibpkg/classify.nim
+++ b/src/nibpkg/classify.nim
@@ -3,8 +3,9 @@ import tables
 import hts
 import ./mainLookup
 import ./read
+import ./svidx
 
-proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef =
+proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32, uint32] =
     result = newCountTable[uint32, uint32]()
 
     var bamfile:Bam
@@ -12,17 +13,20 @@ proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef =
 
     for record in bamfile:
         var read_classification = process_read(record.sequence, idx, k)
-        var filtered_classification = filter_read_matches(read_classification)
-        for key, val in filtered_classification.compatible_SVs:
+        filter_read_matches(read_classification)
+        for key, val in read_classification.compatible_SVs:
             result.mgetOrPut(key, val)
 
 
-proc classify_file(filename : string, idx : svIdx): CountTableRef =
+proc classify_file(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32, uint32] =
     
     if endsWith(filename, ".bam"):
-        return classify_bam
+        return classify_bam(filename, idx, k)
     else:
         quit("Error: only BAM input currently supported.")
 
-proc main_classify(read_file : string, vcf_file : string, ref_file : string, k:int=25) =
-    
+proc main_classify(read_file : string, vcf_file : string, ref_file : string, k:int=25, flank:int=100) =
+
+    var idx : svIdx = buildSVIdx(ref_file, vcf_file, flank, k)
+
+    var svCounts: CountTableRef[uint32, uint32] = classify_file(read_file, idx, k)

--- a/src/nibpkg/classify.nim
+++ b/src/nibpkg/classify.nim
@@ -6,7 +6,7 @@ import ./read
 import ./svidx
 
 proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef[uint32] =
-    result = newCountTable[uint32]()
+    new(result)
 
     var bamfile:Bam
     open(bamfile, filename, index=false)

--- a/src/nibpkg/classify.nim
+++ b/src/nibpkg/classify.nim
@@ -1,0 +1,25 @@
+import strutils
+import tables
+import hts
+import ./mainLookup
+import ./read
+
+proc classify_bam(filename : string, idx : svIdx, k:int=25): CountTableRef =
+    result = newCountTable[uint32, uint32]()
+
+    var bamfile:Bam
+    open(bamfile, filename, index=false)
+
+    for record in bamfile:
+        var read_classification = process_read(record.sequence, idx, k)
+        var filtered_classification = filter_read_matches(read_classification)
+        for key, val in filtered_classification.compatible_SVs:
+            result.mgetOrPut(key, val)
+
+
+proc classify_file(filename : string, idx : svIdx): CountTableRef =
+    
+    if endsWith(filename, ".bam"):
+        return classify_bam
+    else:
+        quit("Error: only BAM input currently supported.")

--- a/src/nibpkg/mainLookup.nim
+++ b/src/nibpkg/mainLookup.nim
@@ -11,7 +11,7 @@ proc lookupKmer*(idx : svIdx, kmer : seed_t): seq[uint32] =
 proc buildSVIdx*(reference_path:string, vcf_path: string, flank:int=100, k:int=25): svIdx =
 
  ## Open FASTA index
- result = newTable[uint64, tuple[refCount: uint32, altCount:uint32, svs:seq[uint32]]]()
+ new(result)
  var fai: Fai
  doAssert fai.open(reference_path), "Failed to open FASTA file: " & reference_path
 

--- a/src/nibpkg/mainLookup.nim
+++ b/src/nibpkg/mainLookup.nim
@@ -5,8 +5,8 @@ import tables
 import msgpack4nim, streams
 import ./svidx
 
-proc lookupKmer(idx : svIdx, kmer : seed_t): seq[uint32] = 
-  return idx[ uint64(kmer.kmer) ].svs
+proc lookupKmer*(idx : svIdx, kmer : seed_t): seq[uint32] =
+  return idx[kmer.kmer].svs
 
 proc buildSVIdx*(reference_path:string, vcf_path: string, flank:int=100, k:int=25): svIdx =
 

--- a/src/nibpkg/read.nim
+++ b/src/nibpkg/read.nim
@@ -1,35 +1,37 @@
 import ./kmers
 import ./mainLookup
 import tables
+export tables
+import ./svidx
 
-type 
-    Read* = object
-        compatible_SVs* : CountTable[uint32]
+type Read* = object
+    ## key of svid, count of supporting kmers
+    compatible_SVs* : CountTable[uint32]
 
 proc process_read*(s : string, idx : svIdx, k:int=25): Read =
+    # find SVs with kmers intersecting with those from this read.
     var x : Read
     var l = Dna(s).dna_to_kmers(k)
     for kmer in l.seeds:
-        var compats = idx.lookupKmer(kmer)
-        for c in compats:
-            x.mgetOrPut(compatible_SVs[c], 0).inc
-
+        var matching_svs = idx.lookupKmer(kmer)
+        for c in matching_svs:
+            x.compatible_SVs.inc(c)
     return x
 
-proc filter_read_matches*(read : Read, min_matches:int=2, winner_takes_all:bool=false) =
-    
+proc filter_read_matches*(read : var Read, min_matches:int=2, winner_takes_all:bool=false) =
+    ## track sv with most kmer matches
     var removables : seq[uint32]
-    var max_key:uint32=0
-    var max_val:uint32=0
-    for key, val in read.compatible_SVs:
-        if val > min_matches:
-            removables.add(key)
-        if val > max_val:
-            max_key = key
-            max_val = val
+    var max_sv = 0
+    var max_kcnt = 0'u32
+    for sv, kcnt in read.compatible_SVs:
+        if kcnt < min_matches:
+            removables.add(sv)
+        if kcnt > max_kcnt.int:
+            max_sv = sv.int
+            max_kcnt = kcnt.uint32
     for r in removables:
-        compatible_SVs.del(r)
-    
+        read.compatible_SVs.del(r)
+
     if winner_takes_all:
-        clear(compatible_SVs)
-        compatible_SVs[max_key] = val
+        clear(read.compatible_SVs)
+        read.compatible_SVs.inc(max_sv.uint32, max_kcnt.int)

--- a/src/nibpkg/read.nim
+++ b/src/nibpkg/read.nim
@@ -6,7 +6,7 @@ type
     Read* = object
         compatible_SVs* : CountTable[uint32]
 
-proc process_read(s : string, idx : svIdx, k:int=25): Read =
+proc process_read*(s : string, idx : svIdx, k:int=25): Read =
     var x : Read
     var l = Dna(s).dna_to_kmers(k)
     for kmer in l.seeds:
@@ -16,7 +16,7 @@ proc process_read(s : string, idx : svIdx, k:int=25): Read =
 
     return x
 
-proc filter_read_matches(read : Read, min_matches:int=2, winner_takes_all:bool=false) =
+proc filter_read_matches*(read : Read, min_matches:int=2, winner_takes_all:bool=false) =
     
     var removables : seq[uint32]
     var max_key:uint32=0

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -3,3 +3,4 @@
 include "t_kmers.nim"
 include "t_util.nim"
 include "t_welcome.nim"
+import  ./test_read.nim

--- a/tests/test_read.nim
+++ b/tests/test_read.nim
@@ -1,0 +1,15 @@
+import unittest
+import nibpkg/read
+
+suite "read suite":
+  test "test that filter read works":
+
+    var r = Read(compatible_SVs: initCountTable[uint32]())
+    r.compatible_SVs.inc(23, 5)
+    r.compatible_SVs.inc(22, 1)
+
+    r.filter_read_matches()
+
+    check r.compatible_SVs.len == 1
+    check 23 in r.compatible_SVs
+


### PR DESCRIPTION
Adds `classify.nim`, which takes in a BAM and iterates over the records, returning a CountTableRef of supports for each SV.

~Completely untested. Probably worth a test.~
Has one test!