### PR TITLE
Add rpath for OSX

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@
 
 build:
 	nim c src/nibsv.nim
+	install_name_tool -add_rpath /opt/local/lib src/nibsv
 release:
 	nim c -d:release -d:danger src/nibsv.nim
 all:

--- a/makefile
+++ b/makefile
@@ -1,10 +1,16 @@
 #NIMBLE_DIR?=${CURDIR}/nimbleDir
 #export NIMBLE_DIR
 # Alternatively, use --nimbleDir:${NIMBLE_DIR} everywhere
+UNAME=$(shell uname)
+ifeq (${UNAME},Darwin)
+	install=install_name_tool -add_rpath /opt/local/lib
+else
+	install=echo
+endif
 
 build:
 	nim c src/nibsv.nim
-	install_name_tool -add_rpath /opt/local/lib src/nibsv
+	${install} src/nibsv
 release:
 	nim c -d:release -d:danger src/nibsv.nim
 all:


### PR DESCRIPTION
This will not cause anyone else any problems, and it helps me remember what we need for OSX. If you use **homebrew** instead of **macports** for **htslib**, then you won't need `rpath`, but arguably **macports** is doing the right thing by not modifying system directories.