### PR TITLE
Make tests work on Mac w/ macports

### DIFF
--- a/tests/makefile
+++ b/tests/makefile
@@ -1,3 +1,13 @@
+UNAME=$(shell uname)
+ifeq (${UNAME},Darwin)
+	install=install_name_tool -add_rpath /opt/local/lib
+else
+	install=echo
+endif
+
 tests:
-	nim c -r all.nim
+	nim c all.nim
+	${install} all
+	./all
+clean:
 	rm -f all


### PR DESCRIPTION
It worked with homebrew because homebrew puts htslib
(and other libs) into the standard directory. Many people
eschew that practice, and I was advised to switch to macport.
But because MacOS strips DYLD_LIBRARY_PATH from env for any
sub-shell, I have to use install_tool to add an rpath.

Static linking would be another option. I can think of a few others
too. But this one works well enough.